### PR TITLE
Add type3 to the charging station mapping.

### DIFF
--- a/mappings/charging_station.yml
+++ b/mappings/charging_station.yml
@@ -13,5 +13,7 @@ mapping:
   type2_output: "socket:type2:output"
   type2_combo: "socket:type2_combo|int"
   type2_combo_output: "socket:type2_combo:output"
+  type3: "socket:type3|int"
+  type3_output: "socket:type3:output"
   schuko: "socket:schuko|int"
   schuko_output: "socket:schuko:output"


### PR DESCRIPTION
[This station](https://www.openstreetmap.org/node/5126734006#map=19/48.81725/2.32641) has only a type3 socket, so I added the mapping.