### PR TITLE
Add parking:zone to the highways dataset.

### DIFF
--- a/mappings/highways.yml
+++ b/mappings/highways.yml
@@ -9,3 +9,4 @@ mapping:
   surface: surface
   access: access
   ref: ref
+  zone_parking: "parking:zone"


### PR DESCRIPTION
In Montrouge we now have the `parking:zone` attribute on highways. Let's export it to use it everywhere.