### PR TITLE
Update socket type and add ref.

### DIFF
--- a/mappings/charging_station.yml
+++ b/mappings/charging_station.yml
@@ -1,6 +1,7 @@
 name: Stations de recharge de véhicules électriques
 overpass: nwr["amenity"="charging_station"](area.searchArea);
 mapping:
+  ref: "ref:EU:EVSE"
   opening_hours: opening_hours
   parking_fee: "parking:fee"
   owner: owner
@@ -17,5 +18,5 @@ mapping:
   type2_combo_output: "socket:type2_combo:output"
   type3: "socket:type3|int"
   type3_output: "socket:type3:output"
-  schuko: "socket:schuko|int"
-  schuko_output: "socket:schuko:output"
+  typee: "socket:typee|int"
+  typee_output: "socket:typee:output"


### PR DESCRIPTION
Je m'était trompé lors du mapping. C'est du `typee`. Les données sont à jour sur osm.

Voir: https://www.openstreetmap.org/changeset/68070457

cc @nlehuby